### PR TITLE
Usability and flow fixes to chart builder

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -18,7 +18,7 @@ describe('Chart Explorer', function() {
           }
         )
         fetch.put(
-          'https://api.data.world/v0/uploads/data-society/iris-species/files/vega-lite.vl.json',
+          'https://api.data.world/v0/uploads/data-society/iris-species/files/test-title.vl.json',
           { message: 'File uploaded.' }
         )
         fetch.get('glob:*/static/media/licenses*', 'cypress license text')
@@ -110,7 +110,7 @@ describe('Chart Explorer', function() {
     cy.get('.alert-link').should(
       'have.attr',
       'href',
-      'https://data.world/data-society/iris-species/workspace/file?filename=vega-lite.vl.json'
+      'https://data.world/data-society/iris-species/workspace/file?filename=test-title.vl.json'
     )
 
     cy.get('.modal-footer > .btn').click()

--- a/src/components/DatasetSelector.js
+++ b/src/components/DatasetSelector.js
@@ -28,6 +28,9 @@ class DatasetSelector extends Component<Props> {
 
   async setValueIfValid() {
     const { token, defaultValue, limitToProjects } = this.props
+
+    console.log(defaultValue)
+
     if (!defaultValue) return
 
     try {
@@ -40,7 +43,10 @@ class DatasetSelector extends Component<Props> {
       })
       if (resp.ok) {
         const jsonResponse = await resp.json()
-        if (jsonResponse.accessLevel === 'WRITE') {
+        if (
+          jsonResponse.accessLevel === 'WRITE' ||
+          jsonResponse.accessLevel === 'ADMIN'
+        ) {
           if ((limitToProjects && jsonResponse.isProject) || !limitToProjects) {
             this.props.onChange(defaultValue)
           }

--- a/src/components/DatasetSelector.js
+++ b/src/components/DatasetSelector.js
@@ -28,9 +28,6 @@ class DatasetSelector extends Component<Props> {
 
   async setValueIfValid() {
     const { token, defaultValue, limitToProjects } = this.props
-
-    console.log(defaultValue)
-
     if (!defaultValue) return
 
     try {

--- a/src/components/Encoding.js
+++ b/src/components/Encoding.js
@@ -10,6 +10,7 @@ import {
   FormGroup,
   Col,
   ControlLabel,
+  HelpBlock,
   Radio
 } from 'react-bootstrap'
 import Select from 'react-select'
@@ -348,13 +349,19 @@ class Encoding extends Component<EncodingProps> {
                       })}
                       value={encoding.sortField ? encoding.sortField._id : null}
                       onChange={id => {
-                        encoding.setSortField(
-                          encodings.find(e => e._id === id) || null
-                        )
+                        const e = encodings.find(e => e._id === id) || null
+                        encoding.setSortField(e)
                       }}
                       isClearable
                       placeholder="Select a field..."
                     />
+                    {encoding.sortField &&
+                      !encoding.sortField.aggregate && (
+                        <HelpBlock>
+                          Selected sort field does not have an aggregation
+                          function set, defaulting to "sum" for sorting.
+                        </HelpBlock>
+                      )}
                   </Col>
                 </AdvancedFormGroup>
               )}

--- a/src/components/Encoding.module.css
+++ b/src/components/Encoding.module.css
@@ -53,3 +53,7 @@
   padding-left: 16px;
   display: inline-block;
 }
+
+.advancedFormGroup :global(.help-block) {
+  margin-bottom: 0px;
+}

--- a/src/components/SaveAsFileModal.js
+++ b/src/components/SaveAsFileModal.js
@@ -19,6 +19,7 @@ import LoadingAnimation from './LoadingAnimation'
 import VegaLiteImage from './VegaLiteImage'
 import classes from './Modals.module.css'
 import type { StoreType } from '../util/Store'
+import kebabCase from 'lodash/kebabCase'
 
 type Props = {
   onClose: Function,
@@ -29,8 +30,8 @@ type Props = {
 
 class SaveAsFileModal extends Component<Props> {
   id: string = ''
-  filename: string = 'vega-lite.vl.json'
-
+  filename: string =
+    kebabCase(this.props.store.config.title || 'untitled') + '.vl.json'
   response: ?{ message: string, uri: string } = null
   saving: boolean = false
 

--- a/src/util/Store.js
+++ b/src/util/Store.js
@@ -209,7 +209,7 @@ export const ChartConfig = types
                   field: e.sortField.field.name,
                   op:
                     e.sortField.aggregate === null
-                      ? 'average'
+                      ? 'sum'
                       : e.sortField.aggregate,
                   order: sortOrder
                 }
@@ -290,13 +290,20 @@ export const ChartConfig = types
       })
     },
     getSpecWithMinimumAmountOfData(data: Array<Object>) {
-      const values = self.getMinimumAmountOfData(data)
+      const spec = self.generatedSpec
+      let data_block = {}
 
-      return {
-        ...self.generatedSpec,
-        data: {
-          values: values
+      // if the user is still using the runtime bound data block, inject  values, otherwise whatever is there
+      if (spec.data && spec.data.name && spec.data.name === 'source') {
+        data_block.values = self.getMinimumAmountOfData(data)
+      } else if (spec.data) {
+        data_block = {
+          ...spec.data
         }
+      }
+      return {
+        ...spec,
+        data: data_block
       }
     }
   }))

--- a/src/views/App.js
+++ b/src/views/App.js
@@ -242,7 +242,19 @@ class App extends Component<AppP> {
                       '?dataset=data-society/iris-species&query=SELECT+%2A%0AFROM+iris'
                   }}
                 >
-                  Here's an example
+                  Here's an example (with a link to a query)
+                </Link>
+                <br />
+                <Link
+                  data-test="example-link-2"
+                  onClick={this.forceUpdate}
+                  to={{
+                    pathname: '/',
+                    search:
+                      '?s=N4IgbgpgTgzglgewHYgFwEYA0IA2CDGAhgC6IqqgwSFT4AWaIA-IQOYRKkAmAvAFbI8ATw4wAZFxKEq3HnE7QAthC5wSEALSTihDQHcEUHFzEBHAK7QhPKjgj5iAUgBMABhcBBF64BmUBIrejq5eAGyuMHQICKRIrDD4cMRCMDrEEAB0+DBgLgBikdGx8YnJqeqO4S4AwsEerIrIEEIZla7mMBqlQhrpigAOGlCEcRAwba3h1UlC3gAqEAPeAEoj7BkAHjgwG-kAInA+PtAc+BDe8vOL-eNVIXp0J96FMfIlM+XpWR9p5wDMeza02SVyWblWo02212zjyByOJyQZwuSFBNwmwKEZksUCEAH1kv0IDwAMoARQAMiAAL7YfDIHxwVhoUCkYh2NBIcw4HDYRQ0ADWjAARjQQNhTghVHEYGgANqgPFwLhoVzYRkQYyMT4QPFIQjKcUgegjJCaxgbI2EiCMQjmYgII3C+RoHyEbYQbBsVhQCCsdSc7m8kAAL2gjtQxCglmwCXdNtQuHk1CgRpghmItoSHGlzOwpGUAFUkElAzzYxm8nBNSrUFyebTFcq0FgQBqtYmAFRGk1IM04RhCK1CIm2+2O7DO8huj1e1g+v0BxP08ycI1h-xoKMxkBxjmJnDJsUVqCZxPSM5IXNWuBFktn+vB9Onqs1ss4RsgJW15zq6sdx86ToU1zWXBA8FTfMRwTEA7QdJ0XVQGcqDnBd-XSd9sA3CNt09XciH3JMzWPXcMyzS9r3zW8IGLUs6yDE9iFfACg2pABdPkRnMd0SSJfBMJAPRlWIBh6PLEBHiZOgH1Y6kgA'
+                  }}
+                >
+                  Here's another example (with a preconfigured chart)
                 </Link>
               </Col>
             </Row>

--- a/src/views/AuthGate.js
+++ b/src/views/AuthGate.js
@@ -120,7 +120,7 @@ class AuthGate extends Component<{
       this.props.store.setToken(token)
       this.props.history.push({
         path: '/',
-        search: parsedParams.get('state')
+        search: decodeURIComponent(parsedParams.get('state'))
       })
       this.hasValidToken = true
     } catch (e) {


### PR DESCRIPTION
Various quality and flow issue improvements to Chartbuilder corresponding to internal data.world JIRA issue HUB-239.

Changes include:

- Create default file names better when you select to save a vega-lite file (use chart title)
- When no aggregation function is chosen on a sort field - do "sum" instead of defaulting to average
    - add a warning to the sort field selection when no aggregate is set on the target sort field
- Don't overwrite changes to the data block in a vega-lite spec when manual edits are made
- Make sure that dataset/project default name is injected in the save-as dialog when the user is Admin as well as just having write privileges.
- Decode URL params properly in OAuth flow so user doesn't end up dead-ending the first time using Chartbuilder
