### PR TITLE
Add CI env variable so Jest tests will run in correct mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/node:10
     environment:
       BASH_ENV: ~/.env
+      CI: true
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Added a global environment variable so build can run in correct context, especially the Jest tests that are currently failing.