### PR TITLE
DATA-2023 Create insights using markdown body

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -28,7 +28,7 @@ describe('Chart Builder', function() {
           }
         )
         fetch.put(
-          'https://api.data.world/v0/uploads/data-society/iris-species/files/test-title.vl.json',
+          'begin:https://api.data.world/v0/uploads/data-society/iris-species/files/test-title',
           { message: 'File uploaded.' }
         )
         fetch.get('glob:*/static/media/licenses*', 'cypress license text')
@@ -157,7 +157,6 @@ describe('Chart Builder', function() {
     cy.get('[data-test=share-insight]').click()
     cy.get('.modal')
 
-    cy.get('[data-test=insight-save-vega-lite-checkbox]').uncheck()
     cy.get('.btn-primary').click()
 
     cy.get('.alert-link').should(

--- a/src/components/SaveAsInsightModal.js
+++ b/src/components/SaveAsInsightModal.js
@@ -91,9 +91,9 @@ class SaveAsInsightModal extends Component<Props> {
           markdownBody:
             `\`\`\`vega-lite\n ${JSON.stringify(specWithData)} \n\`\`\`\n` +
             this.description +
-            `\n\n Click [here](${chartURL}) to edit this chart` +
+            `\n\n Click [here](${chartURL}) to edit this chart.` +
             (queryResults
-              ? `\n\n Here is the query that generated this chart \n @(${queryResults})`
+              ? `\n\n Here is the query that generated this chart: \n @(${queryResults})`
               : '')
         },
         sourceLink: linkToVLFile

--- a/src/components/SaveAsInsightModal.js
+++ b/src/components/SaveAsInsightModal.js
@@ -9,8 +9,7 @@ import {
   Alert,
   Col,
   Row,
-  Grid,
-  Checkbox
+  Grid
 } from 'react-bootstrap'
 import { decorate, observable } from 'mobx'
 import { observer, inject } from 'mobx-react'
@@ -30,14 +29,6 @@ type Props = {
   data: Array<Object>,
   defaultId: string,
   store: StoreType
-}
-
-function storeBlob(blob: Blob): Promise<{ url: string }> {
-  const filepicker = require('filepicker-js')
-  return new Promise((resolve, reject) => {
-    filepicker.setKey('Al0jca1QpS4iGpimTNsAqz')
-    filepicker.store(blob, resolve, reject)
-  })
 }
 
 class SaveAsInsightModal extends Component<Props> {

--- a/src/util/Store.js
+++ b/src/util/Store.js
@@ -388,7 +388,7 @@ const Store: ModelType<StoreType> = types
     },
     get savedQueryId() {
       const providedSavedQueryId = self.parsedUrlQuery.saved_query
-      if (!providedSavedQueryId) {
+      if (!providedSavedQueryId || providedSavedQueryId.includes('sample')) {
         return null
       }
       return providedSavedQueryId

--- a/src/views/App.js
+++ b/src/views/App.js
@@ -86,7 +86,7 @@ class App extends Component<AppP> {
     })
 
     let res
-    if (store.savedQueryId && !store.savedQueryId.includes('sample')) {
+    if (store.savedQueryId) {
       const savedQueryURL = `${API_HOST}/v0/queries/${
         store.savedQueryId
       }/results?includeTableSchema=true`


### PR DESCRIPTION
Insights created now use markdown as the body of the insight instead of an imageURL. One of the big reasons for the change is that making it as markdown means I can embed an interactive vega-lite visualization instead of just a static png file. 

To test this, you'll need to have chart-builder integration working locally (https://github.com/datadotworld/ui/wiki/Developing-With-Integrations-Locally)

## Testing

I've created a project called [markdown-pr-testing](http://localhost:3000/user10/markdown-pr-testing) using user10 which can be used for testing.

In this project you can see two examples of insights created and you can also create your own insight to ensure that everything works correctly. 

To create your own insight:
1. go into the workspace view of the project 
2. click on the `saved query` query and open it up in local chart builder. 
3. Configure the chart in any way you want
4. Click on share and then insight and fill out the form in the modal
5. After clicking save this should have successfully created an insight in the project. 

## Notes

When you save an insight that was based off of a saved query, then the insight description will also include the query results that the chart is based off of. Otherwise if the query you opened up in chart-builder is unsaved (or is the sample query) then I'm not able to show the query results so that's just omitted. 

Also you'll find that the query results just show up as a URL when you create your own insight. This is because it's pointing to data.world and not localhost:3000. So you'll just need to edit the insight and make the change to localhost:3000 if you want to see the query results.

