### PR TITLE
[DATA-1301] Add tooltips to chart labels

### DIFF
--- a/src/components/Encoding.js
+++ b/src/components/Encoding.js
@@ -11,7 +11,9 @@ import {
   Col,
   ControlLabel,
   HelpBlock,
-  Radio
+  Radio,
+  OverlayTrigger,
+  Tooltip
 } from 'react-bootstrap'
 import Select from 'react-select'
 
@@ -74,6 +76,16 @@ const CHANNEL_OPTIONS = [
     ]
   }
 ]
+
+const overlayDescriptions = {
+  type: 'The encoded field’s type of measurement',
+  aggregate: 'Used to compute aggregate summary statistics over groups of data',
+  bin: 'Binning discretizes numeric values into a set of bins',
+  zero: 'Whether to include zero as the baseline value in the scale or not',
+  scale:
+    'Scales map data values (numbers, dates, categories, etc.) to visual values (pixels, colors, sizes)',
+  sort: 'The sort property determines the order of the scale domain'
+}
 
 const ENCODING_SELECT_STYLES = selectStyles({
   control: () => ({
@@ -149,9 +161,18 @@ class Encoding extends Component<EncodingProps> {
           !disabled && (
             <Form horizontal className={classes.advanced}>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Type:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip> {overlayDescriptions.type} </Tooltip>}
+                >
+                  {/* This div is needed around each property to shrink the container to text (with no margins/padding).
+                      This allows the tooltip to lay right above the text instead of being off-centered. */}
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Type:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -174,9 +195,16 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Aggregate:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip>{overlayDescriptions.aggregate}</Tooltip>}
+                >
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Aggregate:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -210,9 +238,16 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Bin:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip>{overlayDescriptions.bin}</Tooltip>}
+                >
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Bin:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio
@@ -237,9 +272,16 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Zero:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip>{overlayDescriptions.zero}</Tooltip>}
+                >
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Zero:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio
@@ -264,9 +306,16 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Scale:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip>{overlayDescriptions.scale}</Tooltip>}
+                >
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Scale:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -303,9 +352,16 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <Col componentClass={ControlLabel} sm={3}>
-                  Sort:
-                </Col>
+                <OverlayTrigger
+                  placement="top"
+                  overlay={<Tooltip>{overlayDescriptions.sort}</Tooltip>}
+                >
+                  <div>
+                    <Col componentClass={ControlLabel} sm={3}>
+                      Sort:
+                    </Col>
+                  </div>
+                </OverlayTrigger>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio

--- a/src/components/Encoding.js
+++ b/src/components/Encoding.js
@@ -161,23 +161,20 @@ class Encoding extends Component<EncodingProps> {
           !disabled && (
             <Form horizontal className={classes.advanced}>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-type">
-                      {' '}
-                      {overlayDescriptions.type}{' '}
-                    </Tooltip>
-                  }
-                >
-                  {/* This div is needed around each property to shrink the container to text (with no margins/padding).
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-type">
+                        {overlayDescriptions.type}
+                      </Tooltip>
+                    }
+                  >
+                    {/* This div is needed around each property to shrink the container to text (with no margins/padding).
                       This allows the tooltip to lay right above the text instead of being off-centered. */}
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Type:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                    <div className={classes.labelText}>Type:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -200,20 +197,18 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-aggregate">
-                      {overlayDescriptions.aggregate}
-                    </Tooltip>
-                  }
-                >
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Aggregate:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-aggregate">
+                        {overlayDescriptions.aggregate}
+                      </Tooltip>
+                    }
+                  >
+                    <div className={classes.labelText}>Aggregate:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -247,20 +242,18 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-bin">
-                      {overlayDescriptions.bin}
-                    </Tooltip>
-                  }
-                >
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Bin:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-bin">
+                        {overlayDescriptions.bin}
+                      </Tooltip>
+                    }
+                  >
+                    <div className={classes.labelText}>Bin:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio
@@ -285,20 +278,18 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-zero">
-                      {overlayDescriptions.zero}
-                    </Tooltip>
-                  }
-                >
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Zero:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-zero">
+                        {overlayDescriptions.zero}
+                      </Tooltip>
+                    }
+                  >
+                    <div className={classes.labelText}>Zero:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio
@@ -323,20 +314,18 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-scale">
-                      {overlayDescriptions.scale}
-                    </Tooltip>
-                  }
-                >
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Scale:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-scale">
+                        {overlayDescriptions.scale}
+                      </Tooltip>
+                    }
+                  >
+                    <div className={classes.labelText}>Scale:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <SimpleSelect
                     values={[
@@ -373,20 +362,18 @@ class Encoding extends Component<EncodingProps> {
                 </Col>
               </AdvancedFormGroup>
               <AdvancedFormGroup bsSize="xs">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={
-                    <Tooltip id="encoding-sort">
-                      {overlayDescriptions.sort}
-                    </Tooltip>
-                  }
-                >
-                  <div>
-                    <Col componentClass={ControlLabel} sm={3}>
-                      Sort:
-                    </Col>
-                  </div>
-                </OverlayTrigger>
+                <Col componentClass={ControlLabel} sm={3}>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id="encoding-sort">
+                        {overlayDescriptions.sort}
+                      </Tooltip>
+                    }
+                  >
+                    <div className={classes.labelText}>Sort:</div>
+                  </OverlayTrigger>
+                </Col>
                 <Col sm={9}>
                   <InlineFormGroup>
                     <Radio

--- a/src/components/Encoding.js
+++ b/src/components/Encoding.js
@@ -12,8 +12,7 @@ import {
   ControlLabel,
   HelpBlock,
   Radio,
-  OverlayTrigger,
-  Tooltip
+  OverlayTrigger
 } from 'react-bootstrap'
 import Select from 'react-select'
 
@@ -21,6 +20,7 @@ import selectStyles from '../util/selectStyles'
 import FieldSelect from './FieldSelect'
 import classes from './Encoding.module.css'
 import type { EncLineType, FieldType, ChartConfigType } from '../util/Store'
+import { tooltipOverlay } from '../util/util'
 
 const AdvancedFormGroup = props => {
   return <FormGroup className={classes.advancedFormGroup} {...props} />
@@ -164,11 +164,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-type">
-                        {overlayDescriptions.type}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-type',
+                      overlayDescriptions.type
+                    )}
                   >
                     {/* This div is needed around each property to shrink the container to text (with no margins/padding).
                       This allows the tooltip to lay right above the text instead of being off-centered. */}
@@ -200,11 +199,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-aggregate">
-                        {overlayDescriptions.aggregate}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-aggregate',
+                      overlayDescriptions.aggregate
+                    )}
                   >
                     <div className={classes.labelText}>Aggregate:</div>
                   </OverlayTrigger>
@@ -245,11 +243,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-bin">
-                        {overlayDescriptions.bin}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-bin',
+                      overlayDescriptions.bin
+                    )}
                   >
                     <div className={classes.labelText}>Bin:</div>
                   </OverlayTrigger>
@@ -281,11 +278,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-zero">
-                        {overlayDescriptions.zero}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-zero',
+                      overlayDescriptions.zero
+                    )}
                   >
                     <div className={classes.labelText}>Zero:</div>
                   </OverlayTrigger>
@@ -317,11 +313,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-scale">
-                        {overlayDescriptions.scale}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-scale',
+                      overlayDescriptions.scale
+                    )}
                   >
                     <div className={classes.labelText}>Scale:</div>
                   </OverlayTrigger>
@@ -365,11 +360,10 @@ class Encoding extends Component<EncodingProps> {
                 <Col componentClass={ControlLabel} sm={3}>
                   <OverlayTrigger
                     placement="top"
-                    overlay={
-                      <Tooltip id="encoding-sort">
-                        {overlayDescriptions.sort}
-                      </Tooltip>
-                    }
+                    overlay={tooltipOverlay(
+                      'encoding-sort',
+                      overlayDescriptions.sort
+                    )}
                   >
                     <div className={classes.labelText}>Sort:</div>
                   </OverlayTrigger>

--- a/src/components/Encoding.js
+++ b/src/components/Encoding.js
@@ -163,7 +163,12 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip> {overlayDescriptions.type} </Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-type">
+                      {' '}
+                      {overlayDescriptions.type}{' '}
+                    </Tooltip>
+                  }
                 >
                   {/* This div is needed around each property to shrink the container to text (with no margins/padding).
                       This allows the tooltip to lay right above the text instead of being off-centered. */}
@@ -197,7 +202,11 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip>{overlayDescriptions.aggregate}</Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-aggregate">
+                      {overlayDescriptions.aggregate}
+                    </Tooltip>
+                  }
                 >
                   <div>
                     <Col componentClass={ControlLabel} sm={3}>
@@ -240,7 +249,11 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip>{overlayDescriptions.bin}</Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-bin">
+                      {overlayDescriptions.bin}
+                    </Tooltip>
+                  }
                 >
                   <div>
                     <Col componentClass={ControlLabel} sm={3}>
@@ -274,7 +287,11 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip>{overlayDescriptions.zero}</Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-zero">
+                      {overlayDescriptions.zero}
+                    </Tooltip>
+                  }
                 >
                   <div>
                     <Col componentClass={ControlLabel} sm={3}>
@@ -308,7 +325,11 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip>{overlayDescriptions.scale}</Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-scale">
+                      {overlayDescriptions.scale}
+                    </Tooltip>
+                  }
                 >
                   <div>
                     <Col componentClass={ControlLabel} sm={3}>
@@ -354,7 +375,11 @@ class Encoding extends Component<EncodingProps> {
               <AdvancedFormGroup bsSize="xs">
                 <OverlayTrigger
                   placement="top"
-                  overlay={<Tooltip>{overlayDescriptions.sort}</Tooltip>}
+                  overlay={
+                    <Tooltip id="encoding-sort">
+                      {overlayDescriptions.sort}
+                    </Tooltip>
+                  }
                 >
                   <div>
                     <Col componentClass={ControlLabel} sm={3}>

--- a/src/components/Encoding.module.css
+++ b/src/components/Encoding.module.css
@@ -45,6 +45,7 @@
 
 .advancedFormGroup {
   display: flex;
+  justify-content: flex-end;
   align-items: baseline;
   margin-right: -0.5rem;
 }

--- a/src/components/Encoding.module.css
+++ b/src/components/Encoding.module.css
@@ -45,7 +45,6 @@
 
 .advancedFormGroup {
   display: flex;
-  justify-content: flex-end;
   align-items: baseline;
   margin-right: -0.5rem;
 }
@@ -57,4 +56,8 @@
 
 .advancedFormGroup :global(.help-block) {
   margin-bottom: 0px;
+}
+
+.labelText {
+  display: inline-block;
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -65,7 +65,11 @@ class Sidebar extends Component<Props> {
               <div className={classes.title}>Marks</div>
               <OverlayTrigger
                 placement="top"
-                overlay={<Tooltip>{overlayDescriptions.marks}</Tooltip>}
+                overlay={
+                  <Tooltip id="sidebar-marks">
+                    {overlayDescriptions.marks}
+                  </Tooltip>
+                }
               >
                 <img
                   alt="data.world info icon"
@@ -109,7 +113,11 @@ class Sidebar extends Component<Props> {
               Configuration
               <OverlayTrigger
                 placement="top"
-                overlay={<Tooltip>{overlayDescriptions.addEncoding}</Tooltip>}
+                overlay={
+                  <Tooltip id="sidebar-add-encoding">
+                    {overlayDescriptions.addEncoding}
+                  </Tooltip>
+                }
               >
                 <Button
                   data-test="add-encoding"

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,13 +1,6 @@
 // @flow
 import React, { Component } from 'react'
-import {
-  Tabs,
-  Tab,
-  Alert,
-  Button,
-  Tooltip,
-  OverlayTrigger
-} from 'react-bootstrap'
+import { Tabs, Tab, Alert, Button, OverlayTrigger } from 'react-bootstrap'
 import { observer, inject } from 'mobx-react'
 import Editor from './Editor'
 import Encoding from './Encoding'
@@ -16,8 +9,8 @@ import SidebarFooter from './SidebarFooter'
 import SimpleSelect from './SimpleSelect'
 import classes from './Sidebar.module.css'
 import infoIcon from './infoIcon.svg'
-
 import type { StoreType } from '../util/Store'
+import { tooltipOverlay } from '../util/util'
 
 type Props = {
   store: StoreType
@@ -65,11 +58,10 @@ class Sidebar extends Component<Props> {
               <div className={classes.title}>Marks</div>
               <OverlayTrigger
                 placement="top"
-                overlay={
-                  <Tooltip id="sidebar-marks">
-                    {overlayDescriptions.marks}
-                  </Tooltip>
-                }
+                overlay={tooltipOverlay(
+                  'sidebar-marks',
+                  overlayDescriptions.marks
+                )}
               >
                 <img
                   alt="data.world info icon"
@@ -113,11 +105,10 @@ class Sidebar extends Component<Props> {
               Configuration
               <OverlayTrigger
                 placement="top"
-                overlay={
-                  <Tooltip id="sidebar-add-encoding">
-                    {overlayDescriptions.addEncoding}
-                  </Tooltip>
-                }
+                overlay={tooltipOverlay(
+                  'sidebar-add-encoding',
+                  overlayDescriptions.addEncoding
+                )}
               >
                 <Button
                   data-test="add-encoding"

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,6 +1,13 @@
 // @flow
 import React, { Component } from 'react'
-import { Tabs, Tab, Alert, Button } from 'react-bootstrap'
+import {
+  Tabs,
+  Tab,
+  Alert,
+  Button,
+  Tooltip,
+  OverlayTrigger
+} from 'react-bootstrap'
 import { observer, inject } from 'mobx-react'
 import Editor from './Editor'
 import Encoding from './Encoding'
@@ -8,11 +15,19 @@ import GlobalOptions from './GlobalOptions'
 import SidebarFooter from './SidebarFooter'
 import SimpleSelect from './SimpleSelect'
 import classes from './Sidebar.module.css'
+import infoIcon from './infoIcon.svg'
 
 import type { StoreType } from '../util/Store'
 
 type Props = {
   store: StoreType
+}
+
+const overlayDescriptions = {
+  marks:
+    'Marks provide basic shapes whose properties (such as position, size, and color) can be used to visually encode data',
+  addEncoding:
+    'Encodings represent the mapping between encoding channels (such as x, y, or color) and data fields'
 }
 
 class Sidebar extends Component<Props> {
@@ -46,7 +61,23 @@ class Sidebar extends Component<Props> {
                 </Button>
               </Alert>
             )}
-            <div className={classes.title}>Marks</div>
+            <span className={classes.titleContainer}>
+              <div className={classes.title}>Marks</div>
+              <OverlayTrigger
+                placement="top"
+                overlay={<Tooltip>{overlayDescriptions.marks}</Tooltip>}
+              >
+                <img
+                  alt="data.world info icon"
+                  src={infoIcon}
+                  style={{
+                    height: 12,
+                    width: 12,
+                    marginLeft: '0.2rem'
+                  }}
+                />
+              </OverlayTrigger>
+            </span>
             <div data-test="chart-type-selector">
               <SimpleSelect
                 values={[
@@ -76,17 +107,22 @@ class Sidebar extends Component<Props> {
             </div>
             <div className={classes.title}>
               Configuration
-              <Button
-                data-test="add-encoding"
-                bsStyle="link"
-                bsSize="xs"
-                className="pull-right"
-                style={{ paddingLeft: 0, paddingRight: 0 }}
-                onClick={store.config.addEncoding}
-                disabled={store.config.hasManualSpec}
+              <OverlayTrigger
+                placement="top"
+                overlay={<Tooltip>{overlayDescriptions.addEncoding}</Tooltip>}
               >
-                Add encoding
-              </Button>
+                <Button
+                  data-test="add-encoding"
+                  bsStyle="link"
+                  bsSize="xs"
+                  className="pull-right"
+                  style={{ paddingLeft: 0, paddingRight: 0 }}
+                  onClick={store.config.addEncoding}
+                  disabled={store.config.hasManualSpec}
+                >
+                  Add encoding
+                </Button>
+              </OverlayTrigger>
             </div>
             {fields && (
               <div data-test="encodings-list">

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -61,6 +61,12 @@
   margin: 1rem 0;
   margin-top: 1.5rem;
 }
+
+.titleContainer {
+  display: flex;
+  align-items: center;
+}
+
 .title:first-of-type {
   margin-top: 1rem;
 }

--- a/src/components/__tests__/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Sidebar.spec.js.snap
@@ -60,11 +60,31 @@ exports[`renders 1`] = `
         id="configure-tabs-pane-builder"
         role="tabpanel"
       >
-        <div
-          className="title"
+        <span
+          className="titleContainer"
         >
-          Marks
-        </div>
+          <div
+            className="title"
+          >
+            Marks
+          </div>
+          <img
+            alt="data.world info icon"
+            onBlur={[Function]}
+            onClick={null}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            src="infoIcon.svg"
+            style={
+              Object {
+                "height": 12,
+                "marginLeft": "0.2rem",
+                "width": 12,
+              }
+            }
+          />
+        </span>
         <div
           data-test="chart-type-selector"
         >
@@ -139,7 +159,11 @@ exports[`renders 1`] = `
             className="pull-right btn btn-xs btn-link"
             data-test="add-encoding"
             disabled={false}
+            onBlur={[Function]}
             onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
             style={
               Object {
                 "paddingLeft": 0,

--- a/src/components/infoIcon.svg
+++ b/src/components/infoIcon.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>icon/info/blue copy</title>
+    <desc>Created with Sketch.</desc>
+    <g id="ICONS-+-ILLUSTRATIONS" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="icons" transform="translate(-352.000000, -640.000000)" stroke="#6290C3">
+            <g id="status" transform="translate(112.000000, 592.000000)">
+                <g id="icon/info/blue" transform="translate(240.000000, 48.000000)">
+                    <g id="icon">
+                        <path d="M8,15.5 C12.1421356,15.5 15.5,12.1421356 15.5,8 C15.5,3.85786438 12.1421356,0.5 8,0.5 C3.85786438,0.5 0.5,3.85786438 0.5,8 C0.5,12.1421356 3.85786438,15.5 8,15.5 Z" id="Oval"></path>
+                        <polyline id="Shape" stroke-linecap="round" stroke-linejoin="round" points="6.54545455 7.27272727 8 7.27272727 8 11.6363636"></polyline>
+                        <path d="M6.54545455,11.6363636 L9.45454545,11.6363636" id="Shape" stroke-linecap="round" stroke-linejoin="round"></path>
+                        <path d="M8,4.36363636 L8,5.09090909" id="Shape" stroke-linecap="round" stroke-linejoin="round"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,7 @@ body {
 
 .form-horizontal .control-label {
   padding-top: 7px;
+  text-align: left;
 }
 .form-horizontal .form-group {
   margin-bottom: 0;

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,4 +1,6 @@
 // @flow
+import React from 'react'
+import { Tooltip } from 'react-bootstrap'
 
 export function parseParams(searchString: String) {
   const query = new URLSearchParams(searchString)
@@ -26,6 +28,10 @@ export function getDownloadName(baseName: string, extension: string) {
 
 export function encodeFieldName(name: string) {
   return name.replace(/([.[\]])/g, '\\$1')
+}
+
+export function tooltipOverlay(id: string, description: string) {
+  return <Tooltip id={id}>{description}</Tooltip>
 }
 
 type PossibleFieldType = {| name: string, rdfType?: string |}


### PR DESCRIPTION
Addresses: https://dataworld.atlassian.net/browse/DATA-1301

I got the content for the tooltips from vega documentation. If any of the tooltip messages aren't clear or could be written in a better way, then please let me know! 
