### PR TITLE
[DATA-3200] use vega-lite file in insight creation

### DIFF
--- a/src/components/SaveAsInsightModal.js
+++ b/src/components/SaveAsInsightModal.js
@@ -89,7 +89,7 @@ class SaveAsInsightModal extends Component<Props> {
         title: this.title,
         body: {
           markdownBody:
-            `\`\`\`vega-lite\n ${JSON.stringify(specWithData)} \n\`\`\`\n` +
+            `@(${linkToVLFile}) \n ` +
             this.description +
             `\n\n Click [here](${chartURL}) to edit this chart.` +
             (queryResults


### PR DESCRIPTION
This uses the vega-lite file to render the visualization instead of the vega-lite code. 

### Testing

To test this, you'll need to have chart-builder integration working locally (https://github.com/datadotworld/ui/wiki/Developing-With-Integrations-Locally)

I've created a project called markdown-pr-testing using user10 which can be used for testing.

To create your own insight:

1. go into the workspace view of the project
2. click on the saved query query and open it up in local chart builder.
3. Configure the chart in any way you want
4. Click on share and then insight and fill out the form in the modal
5. After clicking save this should have successfully created an insight in the project.

Go back into the project workspace and edit the insight that was just created. It should be referencing a vega-lite file to load the visualization. 

### Notes

 You'll find that it just show up as a URL when you create your own insight. This is because it's pointing to data.world and not localhost:3000. So you'll just need to edit the insight and make the change to localhost:3000 if you want to see the query results locally. In Prod it will work fine since it's already pointing to data.world