### PR TITLE
[PAPPY-365] Chart-builder main build fails with Unsupported Python version detected Python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,9 @@ jobs:
           name: Install AWS Cli
           command: |
             cd /tmp
-            curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-            unzip awscli-bundle.zip
-            ./awscli-bundle/install -i $HOME/.local/aws -b $HOME/.local/bin/aws
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            ./aws/install -i $HOME/.local/aws -b $HOME/.local/bin/aws
             echo "PATH=$HOME/.local/bin:$PATH" | tee -a ~/.env
       - cypress_tests
       - run:


### PR DESCRIPTION
Ticket: https://dataworld.atlassian.net/browse/PAPPY-365

Update the AWS SDK(https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) 