### PR TITLE
[PAPPY-365]Fixed aws command not found issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,7 @@ jobs:
             cd /tmp
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
-            ./aws/install -i $HOME/.local/aws -b $HOME/.local/bin/aws
-            echo "PATH=$HOME/.local/bin:$PATH" | tee -a ~/.env
+            ./aws/install -i ~/.local/aws-cli -b ~/.local/bin
       - cypress_tests
       - run:
           name: Sync to s3


### PR DESCRIPTION
Ticket : https://dataworld.atlassian.net/browse/PAPPY-365

Fix for the Issue is seen after merging the [PR](https://github.com/datadotworld/chart-builder/pull/70).

