### PR TITLE
[IN-4716] Use cypress image for main build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - cypress_tests
   build_main:
     docker:
-      - image: cimg/node:20.7.0
+      - image: cypress/base:latest
     environment:
       BASH_ENV: ~/.env
     steps:


### PR DESCRIPTION
Fixes failing cypress test for the `build_main` job. 

Ticket : https://dataworld.atlassian.net/browse/IN-4716