### PR TITLE
[IN-4716] Add deploy_main job to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,16 +95,16 @@ jobs:
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
             ./aws/install -i ~/.local/aws-cli -b ~/.local/bin
-      # - run:
-      #     name: Sync to s3
-      #     command: |
-      #       aws s3 sync build s3://dataworld-chartbuilder-us-east-1 --exclude "index.html" --exclude "manifest.json" --exclude "service-worker.js" --exclude "asset-manifest.json"
-      #       aws s3 cp build/index.html s3://dataworld-chartbuilder-us-east-1/index.html --cache-control max-age=300
-      #       aws s3 cp build/manifest.json s3://dataworld-chartbuilder-us-east-1/manifest.json --cache-control max-age=300
-      #       aws s3 cp build/service-worker.js s3://dataworld-chartbuilder-us-east-1/service-worker.js --cache-control max-age=300
-      #       aws s3 cp build/asset-manifest.json s3://dataworld-chartbuilder-us-east-1/asset-manifest.json --cache-control max-age=300
-      #     environment:
-      #       AWS_PROFILE: artifacts
+      - run:
+          name: Sync to s3
+          command: |
+            aws s3 sync build s3://dataworld-chartbuilder-us-east-1 --exclude "index.html" --exclude "manifest.json" --exclude "service-worker.js" --exclude "asset-manifest.json"
+            aws s3 cp build/index.html s3://dataworld-chartbuilder-us-east-1/index.html --cache-control max-age=300
+            aws s3 cp build/manifest.json s3://dataworld-chartbuilder-us-east-1/manifest.json --cache-control max-age=300
+            aws s3 cp build/service-worker.js s3://dataworld-chartbuilder-us-east-1/service-worker.js --cache-control max-age=300
+            aws s3 cp build/asset-manifest.json s3://dataworld-chartbuilder-us-east-1/asset-manifest.json --cache-control max-age=300
+          environment:
+            AWS_PROFILE: artifacts
 workflows:
   build:
     jobs:
@@ -113,17 +113,17 @@ workflows:
             branches:
               ignore:
                 - main
-  build_main:
+  build_and_deploy_main:
     jobs:
       - build_main:
           filters:
             branches:
-              ignore:
+              only:
                 - main
       - deploy_main:
           context:
             - aws-artifacts
           filters:
             branches:
-              ignore:
+              only:
                 - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,24 @@ jobs:
       BASH_ENV: ~/.env
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-npm-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - v1-npm-deps-{{ .Branch }}
+            - v1-npm-deps-
+      - run: yarn install
+      - run:
+          name: Jest tests
+          command: yarn test
+      - run: yarn build
+      - cypress_tests
+  deploy_main:
+    docker:
+      - image: cimg/node:20.7.0
+    environment:
+      BASH_ENV: ~/.env
+    steps:
+      - checkout
       - run:
           name: Clone build-scripts repo
           command: git clone git@github.com:datadotworld/build-scripts.git
@@ -67,9 +85,6 @@ jobs:
             - v1-npm-deps-
       - run: yarn install
       - run:
-          name: Jest tests
-          command: yarn test
-      - run:
           name: Generate license text
           command: yarn licenses generate-disclaimer --silent > src/generated/licenses.txt
       - run: yarn build
@@ -80,17 +95,16 @@ jobs:
             curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
             unzip awscliv2.zip
             ./aws/install -i ~/.local/aws-cli -b ~/.local/bin
-      - cypress_tests
-      - run:
-          name: Sync to s3
-          command: |
-            aws s3 sync build s3://dataworld-chartbuilder-us-east-1 --exclude "index.html" --exclude "manifest.json" --exclude "service-worker.js" --exclude "asset-manifest.json"
-            aws s3 cp build/index.html s3://dataworld-chartbuilder-us-east-1/index.html --cache-control max-age=300
-            aws s3 cp build/manifest.json s3://dataworld-chartbuilder-us-east-1/manifest.json --cache-control max-age=300
-            aws s3 cp build/service-worker.js s3://dataworld-chartbuilder-us-east-1/service-worker.js --cache-control max-age=300
-            aws s3 cp build/asset-manifest.json s3://dataworld-chartbuilder-us-east-1/asset-manifest.json --cache-control max-age=300
-          environment:
-            AWS_PROFILE: artifacts
+      # - run:
+      #     name: Sync to s3
+      #     command: |
+      #       aws s3 sync build s3://dataworld-chartbuilder-us-east-1 --exclude "index.html" --exclude "manifest.json" --exclude "service-worker.js" --exclude "asset-manifest.json"
+      #       aws s3 cp build/index.html s3://dataworld-chartbuilder-us-east-1/index.html --cache-control max-age=300
+      #       aws s3 cp build/manifest.json s3://dataworld-chartbuilder-us-east-1/manifest.json --cache-control max-age=300
+      #       aws s3 cp build/service-worker.js s3://dataworld-chartbuilder-us-east-1/service-worker.js --cache-control max-age=300
+      #       aws s3 cp build/asset-manifest.json s3://dataworld-chartbuilder-us-east-1/asset-manifest.json --cache-control max-age=300
+      #     environment:
+      #       AWS_PROFILE: artifacts
 workflows:
   build:
     jobs:
@@ -102,9 +116,14 @@ workflows:
   build_main:
     jobs:
       - build_main:
+          filters:
+            branches:
+              ignore:
+                - main
+      - deploy_main:
           context:
             - aws-artifacts
           filters:
             branches:
-              only:
+              ignore:
                 - main


### PR DESCRIPTION
While https://github.com/datadotworld/chart-builder/pull/82 resolved our cypress test issues, we ran into another issue as the `cypress/base:latest` image is not suitable for our deployment needs. This PR fixes that by separating main build from deployment, that way we're able to apply a suitable image per step.

Build looks good here : 
https://github.com/datadotworld/chart-builder/runs/24682737434
https://github.com/datadotworld/chart-builder/runs/24682737764