### PR TITLE
[IN-6094] Add reauthenticate button to error page

### DIFF
--- a/src/views/App.js
+++ b/src/views/App.js
@@ -270,7 +270,19 @@ class App extends Component<AppP> {
                 }
               />
             ) : (
-              <h4>Error loading data</h4>
+              <div>
+                <h4>Error loading data</h4>
+                <p>Are you authenticated against the correct instance?</p>
+                <Button
+                  bsStyle="primary"
+                  onClick={() => {
+                    localStorage.clear()
+                    window.location.reload()
+                  }}
+                >
+                  Reauthenticate
+                </Button>
+              </div>
             )}
           </Grid>
         </Fragment>


### PR DESCRIPTION
Add reauthenticate button to the error page.  You can only point at one instance at a time, so this is a quick way to switch to a new instance.

<img width="947" alt="image" src="https://github.com/user-attachments/assets/bbb3f4a9-1f0a-45c2-a55e-3d63f82edf15" />

https://dataworld.atlassian.net/browse/IN-6094
